### PR TITLE
deft-deploy module; some reorganizing to use the simple templating

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 _build
 *.hdp
 deft-package-local.json
+*~

--- a/deft-core/deft-core.lid
+++ b/deft-core/deft-core.lid
@@ -6,3 +6,4 @@ files: library
        projects
        registries
        version
+       templates

--- a/deft-core/library.dylan
+++ b/deft-core/library.dylan
@@ -26,6 +26,9 @@ define module deft-core
   use command-interface;
   use file-system;
   use format-out;
+  use format,
+    import: { format,
+              format-to-string };
   use json;
   use locators;
   use release-info;
@@ -54,4 +57,7 @@ define module deft-core
          deft-open-project,
          deft-close-project,
          dylan-current-project;
+  
+  export <template>,
+         write-templates;
 end module;

--- a/deft-core/templates.dylan
+++ b/deft-core/templates.dylan
@@ -1,0 +1,31 @@
+module: deft-core
+synopsis:
+copyright: See LICENSE file in this distribution.
+
+// The <template> class is used to encapsulate constant format strings                                                                        
+// ("templates") and its arguments.                                                                                                            
+
+define class <template> (<object>)
+  constant slot constant-string, required-init-keyword: constant-string:;
+  constant slot arguments, init-keyword: arguments:, init-value: #();
+  constant slot output-path, required-init-keyword: output-path:;
+end class <template>;
+
+define method as
+    (class == <string>, template :: <template>) => (output :: <string>)
+  apply(format-to-string, template.constant-string, template.arguments);
+end method as;
+
+define method print-object
+    (template :: <template>, stream :: <stream>) => ()
+  format(stream, "%s", as(<string>, template));
+end method print-object;
+
+define function write-templates (#rest templates :: <template>) => ();
+  for (template in templates)
+    with-open-file (stream = output-path(template), direction: #"output",
+                    if-does-not-exist: #"create")
+      print-object(template, stream);
+    end with-open-file;
+  end for;
+end function write-templates;

--- a/deft-deploy/deft-deploy.dylan
+++ b/deft-deploy/deft-deploy.dylan
@@ -1,0 +1,72 @@
+module: deft-deploy
+author: Fabrice Leal
+copyright: See LICENSE file in this distribution.
+
+/*
+ * Right now this only checks if the project is an executable or not
+ * We could somehow check if our executable is a http-server, etc etc ...
+ */
+define function heroku-check ();
+  let p = dylan-project($deft-context, #f);
+  let type = project-target-type(p);
+  if (type = #"executable")
+    #t
+  else
+    format-out("heroku: Only executables are supported, this project is a %s", type);
+    #f
+  end if;
+end function;
+
+define command heroku check ($deft-commands)
+  help "Check if a project can be deployed to heroku";
+  implementation
+    begin
+      if (heroku-check())
+	format-out("All seems ok.\n");
+      end if;
+    end;
+end;
+
+define function heroku-deploy ()
+  let p = dylan-project($deft-context, #f);
+  let exe-name = project-executable-name(p);
+  let procfile :: <template>
+    = make(<template>,
+	   output-path: "Procfile",
+	   constant-string: $heroku-file-template,
+	   arguments: list(exe-name));
+  
+  write-templates(procfile);
+end function;
+
+define command heroku deploy ($deft-commands)
+  help "Create a simple Procfile for the current project.";
+  implementation
+    begin
+      if (heroku-check())
+	heroku-deploy();
+      end if;
+    end;
+end;
+
+define function docker-deploy (version :: <string>);
+  let p = dylan-project($deft-context, #f);
+  let exe-name = project-build-filename(p);
+  let procfile :: <template>
+    = make(<template>,
+	   output-path: "Dockerfile",
+	   constant-string: $docker-file-template,
+	   arguments: list(version, exe-name));
+  
+  write-templates(procfile);
+end function;
+
+define command docker deploy ($deft-commands)
+  help "Create a simple Dockerfile for the current project";
+  simple parameter version :: <string>,
+    help: "For now either 2013.2 or latest";
+  implementation
+    begin
+      docker-deploy(version);
+    end;
+end;

--- a/deft-deploy/deft-deploy.lid
+++ b/deft-deploy/deft-deploy.lid
@@ -1,0 +1,5 @@
+library: deft-deploy
+target-type: dll
+files: library
+       deft-deploy
+       template-constants

--- a/deft-deploy/library.dylan
+++ b/deft-deploy/library.dylan
@@ -1,0 +1,29 @@
+module: dylan-user
+author: Fabrice Leal
+copyright: See LICENSE file in this distribution.
+
+define library deft-deploy
+  use common-dylan;
+  use command-interface;
+  use io;
+
+  use environment-protocols;
+
+  use deft-core;
+
+  export deft-deploy;
+end library;
+
+define module deft-deploy
+  use common-dylan;
+  use command-interface;
+
+  use environment-protocols,
+    exclude: { application-filename, application-arguments, parameter-name };
+
+  use format-out;
+  
+  use deft-core;
+end module;
+
+

--- a/deft-deploy/template-constants.dylan
+++ b/deft-deploy/template-constants.dylan
@@ -1,0 +1,12 @@
+module: deft-deploy
+author: Fabrice Leal
+copyright: See LICENSE file in this distribution.
+
+//define constant $heroku-fname-template :: <string> = "Procfile"
+define constant $heroku-file-template :: <string> = 
+  ("web: sh start-process.sh bin/%s\n");
+
+define constant $docker-file-template :: <string> =
+  ("FROM rjmacready/opendylan:%s-onbuild\n"
+   "\n"
+   "CMD [\"_build/bin/%s\"]\n");

--- a/deft-new/deft-new.dylan
+++ b/deft-new/deft-new.dylan
@@ -4,34 +4,6 @@ Copyright: Original Code is Copyright (c) 2012 Dylan Hackers. All rights reserve
 License: See License.txt in this distribution for details.
 Warranty: Distributed WITHOUT WARRANTY OF ANY KIND
 
-// The <template> class is used to encapsulate constant format strings
-// ("templates") and its arguments.
-
-define class <template> (<object>)
-  constant slot constant-string, required-init-keyword: constant-string:;
-  constant slot arguments, init-keyword: arguments:, init-value: #();
-  constant slot output-path, required-init-keyword: output-path:;
-end class <template>;
-
-define method as
-    (class == <string>, template :: <template>) => (output :: <string>)
-  apply(format-to-string, template.constant-string, template.arguments);
-end method as;
-
-define method print-object
-    (template :: <template>, stream :: <stream>) => ()
-  format(stream, "%s", as(<string>, template));
-end method print-object;
-
-define function write-templates (#rest templates :: <template>) => ();
-  for (template in templates)
-    with-open-file (stream = output-path(template), direction: #"output",
-                    if-does-not-exist: #"create")
-      print-object(template, stream);
-    end with-open-file;
-  end for;
-end function write-templates;
-
 define function create-directory?
     (directory :: <directory-locator>, subdirectory-name :: <string>)
  => (subdirectory :: <directory-locator>)

--- a/deft/library.dylan
+++ b/deft/library.dylan
@@ -17,6 +17,7 @@ define library deft
   use deft-dfmc;
   use deft-server;
   use deft-test;
+  use deft-deploy;
 end library;
 
 define module deft
@@ -34,4 +35,5 @@ define module deft
   use deft-dfmc;
   use deft-server;
   use deft-test;
+  use deft-deploy;
 end module;

--- a/registry/generic/deft-deploy
+++ b/registry/generic/deft-deploy
@@ -1,0 +1,1 @@
+abstract://dylan/deft-deploy/deft-deploy.lid


### PR DESCRIPTION
So, besides the new module I took the liberty of moving some code by @waywardmonkeys to a place where I could use it...

Basically you do:

```
deft
> open hello-world
> deploy docker 2013.2
```

to create a Dockerfile to use the 2013.2-onbuild image or simply

```
> deploy heroku 
```

to create a Procfile to launch your executable.

Comments? Suggestions?

EDIT:
formatting
