### PR TITLE
Update Makefile for Open Dylan 2014.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,8 @@ endif
 build: $(APP_SOURCES) check-submodules
 	OPEN_DYLAN_USER_REGISTRIES=$(REGISTRIES) dylan-compiler -build deft
 	# Install things we need to be able to build
-	cp -fp $(OPEN_DYLAN_DIR)/lib/*.jam _build/lib/
+	mkdir -p _build/share/opendylan/
+	cp -frp $(OPEN_DYLAN_DIR)/share/opendylan/build-scripts _build/share/opendylan/
 	cp -rfp $(OPEN_DYLAN_DIR)/lib/runtime _build/lib/
 	if [ -d $(OPEN_DYLAN_DIR)/include ]; then \
 	  cp -rfp $(OPEN_DYLAN_DIR)/include _build/; \

--- a/README.rst
+++ b/README.rst
@@ -14,7 +14,7 @@ Building Deft
 
 You must build Deft with a build of Open Dylan from the master
 branch. Deft relies on features which have been added to Open
-Dylan after the 2013.2 release.
+Dylan in the 2014.1 release.
 
 To get things set up correctly, please use the ``Makefile`` to
 build Deft::


### PR DESCRIPTION
In version 2014.1 the .jam files moved from `/lib/` to
`/share/opendylan/build-scripts`, this change ensures that they're
copied to and from the updated location.

This change is not compatible with versions of Dylan pre-2014.1 and the
README has been updated to show that.